### PR TITLE
MGMT-58 Conscious career growth

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The [engineering ladder at Packback](careers/readme.md) provides a clear progres
 
 Packback conducts performance reviews 3 times a year. In your review, you and your manager will discuss the wins and successes you've had since your last review as well as opportunities for growth and improvement.
 
-In addition to performance reviews, everyone on the engineering team has [weekly 1-on-1s](1-on-1s.md) with their manager.
+In addition to performance reviews, everyone on the engineering team has [weekly 1-on-1s](1-on-1s.md) with their manager. We also have annual conversations about [conscious career growth](career-growth.md) you are progressing towards your long-term career goals.
 
 ## Software Development at Packback
 

--- a/career-growth.md
+++ b/career-growth.md
@@ -1,0 +1,69 @@
+# Conscious Career Growth
+
+It used to be the case that people would stay with one employer for their entire careers. This is no longer the case today. It is normal and expected for most people to move from role to role throughout their lives. That said, you are at Packback right now for a reason! Your job with Packback is an alliance that benefits both parties:
+
+* You apply your unique skills, vision and expertise to move Packback forward as a company.
+* Your work at Packback pushes you to learn new skills, develop your vision and build new expertise.
+
+This exercise is designed to help you think through your ideal future. We'll be looking at the intersection of how your skills, vision and expertise move Packback forward, and how your growth in turn will help Packback to accelerate towards its mission.
+
+## How This Works
+
+First, this is **not a performance conversation, there is no way to fail at this**. We already have tools in place to help you get to your next promotion (performance reviews every trimester, peer reviews yearly, a regular cadence of opportunities for promotion, (1-on-1s)[1-on-1s.md] for weekly coaching). This exercise is not about your next promotion. Conscious career growth is about longer timescales, so try and forget the next year for now.
+
+**This is not an exercise with an end date**. There is no "up and out." When you reach one career milestone it is simply time to look forward to the next. You'll be exploring the overlap between your aspirations and your career at Packback, and revisiting and tweaking regularly. Going into this meeting, both parties should be in a **directional, aspirational mindset!** Don't be afraid or embarrassed to think big. 
+
+This exercise is done with two meetings:
+
+* A skip-level meeting with your manager's manager where you fill out the three questions below
+* A meeting with your manager as part of a standard 1:1, where you tell them what was discussed and talk through how this fits into your day-to-day role.
+
+We'll revisit this exercise yearly, and you should expect to check in with your manager during performance reviews simply to pulse-check. Have answers ready for the first two questions before the first meeting. You may be confident, unsure, excited or nervous. It doesn't matter, just have answers that make you feel something.
+
+## Conscious Career Growth = Timescale + Mission + Goals
+
+### What would you like to be doing in 2-5 years?
+
+> The above question is vague, purposefully so. You may include some, all, or none of the following: Are there any big skills you want to get that you just don't have now? Do you have a desired job title? Desired responsibilities? 
+
+### What are the biggest gaps between your current skills, vision and expertise and those you would need to achieve the goal above?
+
+> One useful way to think about this, if you were submitting your resume to apply for your dream, what issues might a hiring manager flag up?
+
+### How will you close these gaps? How does closing these gaps help you to deliver on Packback's mission?
+
+> In the spirit of the alliance between you and Packback, let's think through the other half of this. When your expertise, vision and skills grow, how will your role at Packback transform and push Packback even faster towards its mission?
+
+> Here we can attach some more concrete goals, on a timescale of 1-2 years, that you want to take to your manager. What is your mission for the next year or two? How will that help you? How will it help Packback?
+
+## Conscious Career Growth Guide for Managers (of Managers)
+
+A quick reminder about the intention of this exercise, to be summarized at the start of all conversations:
+
+* This is not a performance conversation; this is directional and aspirational.
+* There is no failing here.
+* Winning means leaving the meeting excited about future growth, how that growth helps the employee's growth, and how in turn the employee's growth helps Packback.
+
+### Running Meeting 1 (Managers of Managers)
+
+You may not be in this employee's day-to-day life, but you likely are in the sort of role they see themselves in a few years, or, even if you are not, you definitely have significantly more experience and can give concrete guidance around their growth.
+
+Success for you in this meeting is threefold:
+
+* To give the employee the tools to have really productive career conversations with their direct manager.
+* To leave the meeting with a shared excitement with the employee about their future.
+* For the employee to be able to make a direct link between their own growth towards their ideal role and how their growth accelerates Packback.
+
+If you're running these meetings you have been managing people for a while, so there's not a prescribed formula for it. Just be you! A manager of managers at Packback is a strong people person, and you know what you're doing.
+
+### Running Meeting 2 (Managers)
+
+During this meeting, the employee should come prepared with answers to the three questions. You get to be the one who dives into the nitty-gritty of how they're going to do these things.
+
+You should read the answers ahead of time, **if there is a big disconnect between the employee's ideal career direction and their current role, escalate quickly and decisively to your manager, who ran the first meeting with them.** We can work together to figure out a path forward.
+
+Assuming no massive disconnects (which we will handle in a one-off manner), success for you looks like the following:
+
+* You have a good understanding of what the employee wants to be doing in their ideal role.
+* You have been able to extract parts of their job and immediate career growth that align with their ideal role, and know how to get these into the employee's OKRs.
+* You both leave the meeting excited about the future, and your continued growth together.


### PR DESCRIPTION
## Summary of Changes

* [x] **I acknowledge that this is a public repository, visible to anyone on the internet.**

Engineering at Packback has a lot of processes and structure around an engineer's path to promotion.

While we have some informal processes in place (such as in 1:1s and performance reviews), we don't have any official structure around tracking and supporting an engineer's long-term career growth. The goal of this documentation is to formalize a process for talking about long-term career growth.

